### PR TITLE
Change the string matching rule of the magnet serial communication for  poor wire communication

### DIFF
--- a/jsk_mbzirc_board/scripts/serial_board.py
+++ b/jsk_mbzirc_board/scripts/serial_board.py
@@ -9,7 +9,7 @@ class Serial_board:
     def __init__(self):
         self.T_HEADER = 'TH'
         self.T_TAIL = 'TT'
-        self.Magdata = 'mag:!'
+        self.Magdata = 'g:!' # original is 'mag:!'
         self.port = '/dev/ttyUSB1'
         self.baud = 115200
         self.serialtimeout = 0.01
@@ -59,9 +59,8 @@ class Serial_board:
                 rospy.loginfo(data_in)
                 #data will be like mag:!5!
                 index = data_in.find(self.Magdata)
-                if not (index < 0):
-                    index +=5
-                    self._pub_magnet.publish(int(data_in[index:data_in.find('!',index)]))
+                if not (index < 0) and len(data_in) > index + 4:
+                    self._pub_magnet.publish(int(data_in[index + 3]))
             r.sleep()
 
 


### PR DESCRIPTION
The receive data sometimes are not complete as below:
```
[INFO] [1485146490.043639]: g:!0!
[INFO] [1485146490.148787]: ag:!0!
[INFO] [1485146490.394263]: !
[INFO] [1485146490.495248]: g:!0!
[INFO] [1485146490.599199]: ag:!0!
[INFO] [1485146490.698292]: ag:!0!
[INFO] [1485146490.946891]: :!0!
[INFO] [1485146491.047616]: ag:!0!
[INFO] [1485146491.148308]: ag:!0!
[INFO] [1485146491.395075]: :!0!
[INFO] [1485146491.493710]: g:!0!
[INFO] [1485146491.592281]: ag:!0!
[INFO] [1485146491.696510]: ag:!0!
[INFO] [1485146491.945960]: :!0!
[INFO] [1485146492.047622]: ag:!0!
[INFO] [1485146492.156664]: ag:!0!
[INFO] [1485146492.395954]: g:!0!
[INFO] [1485146492.497843]: g:!0!
[INFO] [1485146492.596778]: ag:!0!
[INFO] [1485146492.696973]: ag:!0!
[INFO] [1485146492.947984]: :!0!
[INFO] [1485146493.047613]: g:!0!
[INFO] [1485146493.148271]: ag:!0!
[INFO] [1485146493.397171]: :!0!
[INFO] [1485146493.497688]: g:!0!
[INFO] [1485146493.597481]: ag:!0!
[INFO] [1485146493.698156]: ag:!0!
[INFO] [1485146493.947258]: :!0!
[INFO] [1485146494.043353]: 0!
[INFO] [1485146494.148738]: ag:!0!
[INFO] [1485146494.395068]: !0!
[INFO] [1485146494.496228]: g:!0!
[INFO] [1485146494.598825]: ag:!0!
[INFO] [1485146494.703733]: ag:!0!
[INFO] [1485146494.944373]: :!0!
[INFO] [1485146495.047047]: g:!0!
[INFO] [1485146495.146840]: ag:!0!
[INFO] [1485146495.247470]: ag:!0!

So I change the matching rule of the receive stream.
```